### PR TITLE
Circle CI enforce to use Docker Authentication for Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,21 @@
+# GLOBAL-ANCHORS - DockerHub Authentication changes applied - PROD-1431 / PROD-1435
+global_dockerhub_login: &global_dockerhub_login
+  run:
+    name: Authenticate with hub.docker.com - DockerHub
+    command: docker login -u $GLOBAL_DOCKERHUB_USERNAME -p $GLOBAL_DOCKERHUB_PASSWORD
+global_context: &global_context
+  context:
+    - org-global
+global_dockerhub_auth: &global_dockerhub_auth
+  auth:
+    username: $GLOBAL_DOCKERHUB_USERNAME
+    password: $GLOBAL_DOCKERHUB_PASSWORD
 version: 2
 jobs:
   build:
     docker:
       - image: circleci/golang:1.14
+        <<: *global_dockerhub_auth
     working_directory: ~/src/jsonrpc-go
     steps:
       - restore_cache:
@@ -15,23 +28,22 @@ jobs:
           key: v1-pkg-cache
           paths:
             - "/go/pkg"
-
   lint:
     docker:
       - image: circleci/golang:1.14
+        <<: *global_dockerhub_auth
     working_directory: ~/src/jsonrpc-go
     steps:
       - checkout
       - run: make setup
       - run: make lint
-
   test:
     docker:
       - image: circleci/golang:1.14
+        <<: *global_dockerhub_auth
     working_directory: ~/src/jsonrpc-go
     environment:
       TEST_RESULTS: /tmp/test-results
-
     steps:
       - checkout
       - run: mkdir -p $TEST_RESULTS
@@ -47,31 +59,35 @@ jobs:
           destination: raw-test-output
       - store_test_results:
           path: /tmp/test-results
-
   release:
     docker:
       - image: deliveroo/semantic-release:1.3.0
+        <<: *global_dockerhub_auth
     steps:
       - checkout
       - run: semantic-release -r ${CIRCLE_REPOSITORY_URL}
-
   commitlint:
     docker:
       - image: deliveroo/semantic-release:1.3.0
+        <<: *global_dockerhub_auth
     environment:
       - DEFAULT_BRANCH=origin/master
     steps:
+      - *global_dockerhub_login
       - checkout
       - run: commitlint --from $(git rev-parse $DEFAULT_BRANCH) --to $CIRCLE_SHA1 --verbose
-
 workflows:
   version: 2
   all:
     jobs:
-      - build
-      - commitlint
-      - lint
-      - test
+      - build:
+          <<: *global_context
+      - commitlint:
+          <<: *global_context
+      - lint:
+          <<: *global_context
+      - test:
+          <<: *global_context
       - release:
           requires:
             - build
@@ -82,3 +98,4 @@ workflows:
             branches:
               only:
                 - master
+          <<: *global_context


### PR DESCRIPTION
PROD-1435: Changes relating to enforcing Docker Hub authentication on CircleCI

- Enforces all actions using Docker Hub to use authentication (not anonymous)
  using CircleCI Global Context - org-global

- Changes Docker setup_remote_docker version to be updated to 19.03.13 due to
  deprecation from CircleCI of older versions

